### PR TITLE
Style: Fix the code in accordance to cpplint

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,4 @@
+set noparent
+filter=-legal/copyright,-build/include_subdir
+linelength=80
+root=src

--- a/src/FusionEKF.cpp
+++ b/src/FusionEKF.cpp
@@ -1,12 +1,13 @@
 #include "FusionEKF.h"
-#include "tools.h"
-#include "Eigen/Dense"
 #include <iostream>
+#include "Eigen/Dense"
+#include "tools.h"
 
-using namespace std;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 using std::vector;
+using std::cout;
+using std::endl;
 
 /*
  * Constructor.
@@ -22,22 +23,20 @@ FusionEKF::FusionEKF() {
   H_laser_ = MatrixXd(2, 4);
   Hj_ = MatrixXd(3, 4);
 
-  //measurement covariance matrix - laser
+  // measurement covariance matrix - laser
   R_laser_ << 0.0225, 0,
-        0, 0.0225;
+              0, 0.0225;
 
-  //measurement covariance matrix - radar
+  // measurement covariance matrix - radar
   R_radar_ << 0.09, 0, 0,
-        0, 0.0009, 0,
-        0, 0, 0.09;
+              0, 0.0009, 0,
+              0, 0, 0.09;
 
   /**
   TODO:
     * Finish initializing the FusionEKF.
     * Set the process and measurement noises
   */
-
-
 }
 
 /**
@@ -46,8 +45,6 @@ FusionEKF::FusionEKF() {
 FusionEKF::~FusionEKF() {}
 
 void FusionEKF::ProcessMeasurement(const MeasurementPackage &measurement_pack) {
-
-
   /*****************************************************************************
    *  Initialization
    ****************************************************************************/
@@ -67,11 +64,10 @@ void FusionEKF::ProcessMeasurement(const MeasurementPackage &measurement_pack) {
       /**
       Convert radar from polar to cartesian coordinates and initialize state.
       */
-    }
-    else if (measurement_pack.sensor_type_ == MeasurementPackage::LASER) {
+    } else if (measurement_pack.sensor_type_ == MeasurementPackage::LASER) {
       /**
-      Initialize state.
-      */
+       Initialize state.
+       */
     }
 
     // done initializing, no need to predict or update

--- a/src/FusionEKF.h
+++ b/src/FusionEKF.h
@@ -1,16 +1,16 @@
-#ifndef FusionEKF_H_
-#define FusionEKF_H_
+#ifndef FUSIONEKF_H_
+#define FUSIONEKF_H_
 
-#include "measurement_package.h"
-#include "Eigen/Dense"
 #include <vector>
 #include <string>
 #include <fstream>
+#include "Eigen/Dense"
+#include "measurement_package.h"
 #include "kalman_filter.h"
 #include "tools.h"
 
 class FusionEKF {
-public:
+ public:
   /**
   * Constructor.
   */
@@ -31,12 +31,13 @@ public:
   */
   KalmanFilter ekf_;
 
-private:
-  // check whether the tracking toolbox was initiallized or not (first measurement)
+ private:
+  // check whether the tracking toolbox was initiallized or not
+  // (first measurement)
   bool is_initialized_;
 
   // previous timestamp
-  long long previous_timestamp_;
+  int64_t previous_timestamp_;
 
   // tool object used to compute Jacobian and RMSE
   Tools tools;
@@ -46,4 +47,4 @@ private:
   Eigen::MatrixXd Hj_;
 };
 
-#endif /* FusionEKF_H_ */
+#endif  // FUSIONEKF_H_

--- a/src/ground_truth_package.h
+++ b/src/ground_truth_package.h
@@ -4,16 +4,15 @@
 #include "Eigen/Dense"
 
 class GroundTruthPackage {
-public:
-  long long timestamp_;
+ public:
+  int64_t timestamp_;
 
-  enum SensorType{
+  enum SensorType {
     LASER,
     RADAR
   } sensor_type_;
 
   Eigen::VectorXd gt_values_;
-
 };
 
 #endif /* GROUND_TRUTH_PACKAGE_H_ */

--- a/src/kalman_filter.cpp
+++ b/src/kalman_filter.cpp
@@ -7,8 +7,9 @@ KalmanFilter::KalmanFilter() {}
 
 KalmanFilter::~KalmanFilter() {}
 
-void KalmanFilter::Init(VectorXd &x_in, MatrixXd &P_in, MatrixXd &F_in,
-                        MatrixXd &H_in, MatrixXd &R_in, MatrixXd &Q_in) {
+void KalmanFilter::Init(const VectorXd &x_in, const MatrixXd &P_in,
+                        const MatrixXd &F_in, const MatrixXd &H_in,
+                        const MatrixXd &R_in, const MatrixXd &Q_in) {
   x_ = x_in;
   P_ = P_in;
   F_ = F_in;

--- a/src/kalman_filter.h
+++ b/src/kalman_filter.h
@@ -2,26 +2,28 @@
 #define KALMAN_FILTER_H_
 #include "Eigen/Dense"
 
-class KalmanFilter {
-public:
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
 
+class KalmanFilter {
+ public:
   // state vector
-  Eigen::VectorXd x_;
+  VectorXd x_;
 
   // state covariance matrix
-  Eigen::MatrixXd P_;
+  MatrixXd P_;
 
   // state transistion matrix
-  Eigen::MatrixXd F_;
+  MatrixXd F_;
 
   // process covariance matrix
-  Eigen::MatrixXd Q_;
+  MatrixXd Q_;
 
   // measurement matrix
-  Eigen::MatrixXd H_;
+  MatrixXd H_;
 
   // measurement covariance matrix
-  Eigen::MatrixXd R_;
+  MatrixXd R_;
 
   /**
    * Constructor
@@ -42,8 +44,8 @@ public:
    * @param R_in Measurement covariance matrix
    * @param Q_in Process covariance matrix
    */
-  void Init(Eigen::VectorXd &x_in, Eigen::MatrixXd &P_in, Eigen::MatrixXd &F_in,
-      Eigen::MatrixXd &H_in, Eigen::MatrixXd &R_in, Eigen::MatrixXd &Q_in);
+  void Init(const VectorXd &x_in, const MatrixXd &P_in, const MatrixXd &F_in,
+      const MatrixXd &H_in, const MatrixXd &R_in, const MatrixXd &Q_in);
 
   /**
    * Prediction Predicts the state and the state covariance
@@ -63,7 +65,6 @@ public:
    * @param z The measurement at k+1
    */
   void UpdateEKF(const Eigen::VectorXd &z);
-
 };
 
-#endif /* KALMAN_FILTER_H_ */
+#endif  // KALMAN_FILTER_H_

--- a/src/measurement_package.h
+++ b/src/measurement_package.h
@@ -4,10 +4,10 @@
 #include "Eigen/Dense"
 
 class MeasurementPackage {
-public:
-  long long timestamp_;
+ public:
+  uint64_t timestamp_;
 
-  enum SensorType{
+  enum SensorType {
     LASER,
     RADAR
   } sensor_type_;

--- a/src/tools.h
+++ b/src/tools.h
@@ -3,8 +3,10 @@
 #include <vector>
 #include "Eigen/Dense"
 
+using std::vector;
+
 class Tools {
-public:
+ public:
   /**
   * Constructor.
   */
@@ -18,13 +20,13 @@ public:
   /**
   * A helper method to calculate RMSE.
   */
-  Eigen::VectorXd CalculateRMSE(const std::vector<Eigen::VectorXd> &estimations, const std::vector<Eigen::VectorXd> &ground_truth);
+  Eigen::VectorXd CalculateRMSE(const vector<Eigen::VectorXd> &estimations,
+                                const vector<Eigen::VectorXd> &ground_truth);
 
   /**
   * A helper method to calculate Jacobians.
   */
   Eigen::MatrixXd CalculateJacobian(const Eigen::VectorXd& x_state);
-
 };
 
 #endif /* TOOLS_H_ */


### PR DESCRIPTION
Fix/Ignored 70 style issues according to cpplint, majorly styles and
formatting issues. This commit also adds const keyword to references
inputs of the following method and function:
KalmanFilter::Init
tools.cpp/check_files

cpplint is a tool for linting C++ code according to Google C++ style
guide, and can be installed using:
```
pip install cpplint
```