### PR TITLE
update to fix issue of cmake error not find openssl

### DIFF
--- a/install-mac.sh
+++ b/install-mac.sh
@@ -7,7 +7,8 @@ patch CMakeLists.txt < ../cmakepatch.txt
 mkdir build
 export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig 
 cd build
-cmake ..
+OPENSSL_VERSION=`openssl version -v | cut -d' ' -f2`
+cmake -DOPENSSL_ROOT_DIR=$(brew --cellar openssl)/$OPENSSL_VERSION -DOPENSSL_LIBRARIES$(brew --cellar openssl)/$OPENSSL_VERSION/lib ..
 make 
 sudo make install
 cd ..

--- a/install-mac.sh
+++ b/install-mac.sh
@@ -8,7 +8,7 @@ mkdir build
 export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig 
 cd build
 OPENSSL_VERSION=`openssl version -v | cut -d' ' -f2`
-cmake -DOPENSSL_ROOT_DIR=$(brew --cellar openssl)/$OPENSSL_VERSION -DOPENSSL_LIBRARIES$(brew --cellar openssl)/$OPENSSL_VERSION/lib ..
+cmake -DOPENSSL_ROOT_DIR=$(brew --cellar openssl)/$OPENSSL_VERSION -DOPENSSL_LIBRARIES=$(brew --cellar openssl)/$OPENSSL_VERSION/lib ..
 make 
 sudo make install
 cd ..


### PR DESCRIPTION
This PR aims to fix error of cmake not find openssl in mac while run install-mac.sh.

Reference issues: 
#32 
#51 