### PR TITLE
Remove websocket close call causing infinite recursion

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,7 +156,6 @@ int main() {
 
   h.onDisconnection([&h](uWS::WebSocket<uWS::SERVER> ws, int code, 
                          char *message, size_t length) {
-    ws.close();
     std::cout << "Disconnected" << std::endl;
   });
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,8 @@
+#include <cstdlib>
 #include <math.h>
-#include <uWS/uWS.h>
 #include <iostream>
+
+#include <uWS/uWS.h>
 #include "json.hpp"
 #include "FusionEKF.h"
 #include "tools.h"
@@ -150,13 +152,14 @@ int main() {
 
   }); // end h.onMessage
 
-  h.onConnection([&h](uWS::WebSocket<uWS::SERVER> ws, uWS::HttpRequest req) {
+  h.onConnection([](uWS::WebSocket<uWS::SERVER> ws, uWS::HttpRequest req) {
     std::cout << "Connected!!!" << std::endl;
   });
 
-  h.onDisconnection([&h](uWS::WebSocket<uWS::SERVER> ws, int code, 
+  h.onDisconnection([](uWS::WebSocket<uWS::SERVER> ws, int code, 
                          char *message, size_t length) {
     std::cout << "Disconnected" << std::endl;
+    std::exit(0);
   });
 
   int port = 4567;


### PR DESCRIPTION
Call to `ws.close()` will immediately call the `onDisconnection` callback again creating an infinite recursion.  Fix is to delete redundant call to `ws.close()`.

Fix tested in recent Debian distribution.