### PR TITLE
Return empty RMSE to start so there's no segfault

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -10,10 +10,15 @@ Tools::Tools() {}
 Tools::~Tools() {}
 
 VectorXd Tools::CalculateRMSE(const vector<VectorXd> &estimations,
-                              const vector<VectorXd> &ground_truth) {
+                              const vector<VectorXd> &ground_truth) {  
+  VectorXd rmse(4);
+  rmse << 0,0,0,0;
+
   /**
    * TODO: Calculate the RMSE here.
    */
+
+  return rmse;
 }
 
 MatrixXd Tools::CalculateJacobian(const VectorXd& x_state) {


### PR DESCRIPTION
I was trying to get the code running but I kept getting segmentation faults before even touching any code... This helps with the segfault and allows you to run right off the bat.