### PR TITLE
docs: Describe workaround for Term 2 Simulator bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Self-Driving Car Engineer Nanodegree Program
 In this project you will utilize a kalman filter to estimate the state of a moving object of interest with noisy lidar and radar measurements. Passing the project requires obtaining RMSE values that are lower than the tolerance outlined in the project rubric. 
 
 This project involves the Term 2 Simulator which can be downloaded [here](https://github.com/udacity/self-driving-car-sim/releases).
+In order to run the simulator on some newer Linux versions, you will need to uncheck the Windowed option.
 
 This repository includes two files that can be used to set up and install [uWebSocketIO](https://github.com/uWebSockets/uWebSockets) for either Linux or Mac systems. For windows you can use either Docker, VMware, or even [Windows 10 Bash on Ubuntu](https://www.howtogeek.com/249966/how-to-install-and-use-the-linux-bash-shell-on-windows-10/) to install uWebSocketIO. Please see the uWebSocketIO Starter Guide page in the classroom within the EKF Project lesson for the required version and installation scripts.
 


### PR DESCRIPTION
The Term 2 Simulator is not compatible with some newer
Linux versions and will crash unless the Windowed option
is unchecked.  
One sentence was added to the readme.

See github.com/udacity/self-driving-car-sim issue #128